### PR TITLE
requirements_github - adds git+ to urls

### DIFF
--- a/requirements_github.txt
+++ b/requirements_github.txt
@@ -8,8 +8,8 @@ wand
 M2Crypto
 python-mimeparse
 dateutils
-https://github.com/Digital-Preservation-Finland/xml-helpers.git#egg=xml_helpers
-https://github.com/Digital-Preservation-Finland/mets.git#egg=mets
-https://github.com/Digital-Preservation-Finland/premis.git#egg=premis
-https://github.com/Digital-Preservation-Finland/dpres-signature.git#egg=dpres_signature
-https://github.com/Digital-Preservation-Finland/dpres-ipt.git#egg=ipt
+git+https://github.com/Digital-Preservation-Finland/xml-helpers.git#egg=xml_helpers
+git+https://github.com/Digital-Preservation-Finland/mets.git#egg=mets
+git+https://github.com/Digital-Preservation-Finland/premis.git#egg=premis
+git+https://github.com/Digital-Preservation-Finland/dpres-signature.git#egg=dpres_signature
+git+https://github.com/Digital-Preservation-Finland/dpres-ipt.git#egg=ipt


### PR DESCRIPTION
Hi, I am not using a virtualenv (cos I couldn't get python-magic to import - but that's another story), so I am just installing dpres-siptools as a regular project.
I kept getting errors when installing the dependencies, until I made the changes in this pull request. It looks like ye had the `git+` format in use previously, so there was probably a good reason for the removal, but I thought I'd send this anyhow.

Previous error:
```
Collecting dateutils (from -r requirements_github.txt (line 10))
  Downloading dateutils-0.6.6.tar.gz
Collecting xml_helpers from https://github.com/Digital-Preservation-Finland/xml-helpers.git#egg=xml_helpers (from -r requirements_github.txt (line 11))
  Downloading https://github.com/Digital-Preservation-Finland/xml-helpers.git
     \ 61kB 310kB/s
  Cannot unpack file /tmp/pip-H2SCyc-unpack/xml-helpers.git (downloaded from /tmp/pip-build-SueE_k/xml-helpers, content-type: text/html; charset=utf-8); cannot detect archive format
Cannot determine archive format of /tmp/pip-build-SueE_k/xml-helpers

```
