### PR TITLE
Reuse PREMIS agent in 'premis-event'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,12 @@ def run_cli():
         :rtype: click.testing.Result
         """
         runner = CliRunner()
-        result = runner.invoke(cli_func, args)
+        result = runner.invoke(
+            cli_func, args,
+            # If the command is meant to succeed, let pytest catch the
+            # exceptions instead of Click
+            catch_exceptions=not success
+        )
         if success:
             assert result.exit_code == 0, result
         else:


### PR DESCRIPTION
If a PREMIS agent with the same name and type already exists, use its agent identifier instead of trying to create a new agent identifier, as it will end up pointing to a non-existent PREMIS agent.