### PR TITLE
Ensure error message is not truncated on Py2

### DIFF
--- a/siptools/scripts/import_object.py
+++ b/siptools/scripts/import_object.py
@@ -194,7 +194,10 @@ class PremisCreator(MdCreator):
                         for error in info['errors']:
                             errors.append(error)
                 error_str = "\n".join(errors)
-                raise ValueError(error_str)
+                # Ensure the error string is binary on Py2, Unicode on Py3.
+                # This ensures the message is not truncated on Py2 if it
+                # contains Unicode.
+                raise ValueError(six.ensure_str(error_str))
         else:
             scraper.scrape(False)
 


### PR DESCRIPTION
If an Unicode string is provided to an exception and it contains non-ASCII symbols, only the name of the exception will be printed.

Ensure the complete message is printed on both Python 2 & 3 by coercing the message to binary on Python 2.