### PR TITLE
Ensure error message is not truncated on Python 2

### DIFF
--- a/siptools/utils.py
+++ b/siptools/utils.py
@@ -127,7 +127,9 @@ def scrape_file(filepath, filerel=None, workspace=None, mimetype=None,
             error_head = "Metadata of file %s could not " \
                          "be collected due to errors.\n" % filepath
             error_str = error_head + error_str
-        raise ValueError(six.text_type(error_str))
+        # Ensure exception is printed in full on both Python 2 & 3 by coercing
+        # to 'str'
+        raise ValueError(six.ensure_str(error_str))
 
     if scraper.info[0]['class'] == 'FileExists' and scraper.info[0]['errors']:
         raise IOError(scraper.info[0]['errors'])


### PR DESCRIPTION
Only 'ValueError' will be printed on Python 2 if the string contains non-ASCII symbols and it isn't coerced into binary (eg. 'str' on Python 2).

Supersedes earlier GitHub pull request Digital-Preservation-Finland/dpres-siptools#7